### PR TITLE
Refactor ui package's classes.

### DIFF
--- a/app/src/main/java/com/u1fukui/bbs/customview/ArrayRecyclerAdapter.kt
+++ b/app/src/main/java/com/u1fukui/bbs/customview/ArrayRecyclerAdapter.kt
@@ -3,7 +3,9 @@ package com.u1fukui.bbs.customview
 import android.support.annotation.UiThread
 import android.support.v7.widget.RecyclerView
 
-abstract class ArrayRecyclerAdapter<T, VH : RecyclerView.ViewHolder> @JvmOverloads constructor(protected val list: MutableList<T> = ArrayList()) : RecyclerView.Adapter<VH>() {
+abstract class ArrayRecyclerAdapter<T, VH : RecyclerView.ViewHolder> @JvmOverloads constructor(
+        protected val list: MutableList<T> = ArrayList()
+) : RecyclerView.Adapter<VH>() {
 
     @UiThread
     fun reset(items: Collection<T>) {

--- a/app/src/main/java/com/u1fukui/bbs/customview/BindingHolder.kt
+++ b/app/src/main/java/com/u1fukui/bbs/customview/BindingHolder.kt
@@ -8,11 +8,13 @@ import android.support.v7.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.ViewGroup
 
-class BindingHolder<T : ViewDataBinding>(context: Context, parent: ViewGroup, @LayoutRes layoutResId: Int) : RecyclerView.ViewHolder(LayoutInflater.from(context).inflate(layoutResId, parent, false)) {
+class BindingHolder<out T : ViewDataBinding>(
+        context: Context,
+        parent: ViewGroup,
+        @LayoutRes layoutResId: Int
+) : RecyclerView.ViewHolder(
+        LayoutInflater.from(context).inflate(layoutResId, parent, false)
+) {
 
-    val binding: T
-
-    init {
-        binding = DataBindingUtil.bind(itemView)
-    }
+    val binding: T = DataBindingUtil.bind(itemView)
 }

--- a/app/src/main/java/com/u1fukui/bbs/customview/ErrorView.kt
+++ b/app/src/main/java/com/u1fukui/bbs/customview/ErrorView.kt
@@ -13,25 +13,17 @@ import android.widget.TextView
 
 import com.u1fukui.bbs.R
 
-class ErrorView : LinearLayout {
+class ErrorView @JvmOverloads constructor(
+        context: Context,
+        attrs: AttributeSet? = null,
+        defStyleAttr: Int = 0
+) : LinearLayout(context, attrs, defStyleAttr) {
 
     interface ErrorViewListener {
         fun onClickReloadButton()
     }
 
-    constructor(context: Context) : super(context) {
-        init()
-    }
-
-    constructor(context: Context, attrs: AttributeSet) : super(context, attrs) {
-        init()
-    }
-
-    constructor(context: Context, attrs: AttributeSet, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
-        init()
-    }
-
-    private fun init() {
+    init {
         orientation = LinearLayout.VERTICAL
         gravity = Gravity.CENTER
         DataBindingUtil.inflate<ViewDataBinding>(LayoutInflater.from(context), R.layout.view_error, this, true)

--- a/app/src/main/java/com/u1fukui/bbs/customview/ObservableListRecyclerAdapter.kt
+++ b/app/src/main/java/com/u1fukui/bbs/customview/ObservableListRecyclerAdapter.kt
@@ -6,7 +6,6 @@ import android.support.v7.widget.RecyclerView
 abstract class ObservableListRecyclerAdapter<T, VH : RecyclerView.ViewHolder>(list: ObservableList<T>) : ArrayRecyclerAdapter<T, VH>(list) {
 
     init {
-
         list.addOnListChangedCallback(object : ObservableList.OnListChangedCallback<ObservableList<T>>() {
             override fun onChanged(contributorViewModels: ObservableList<T>) {
                 notifyDataSetChanged()

--- a/app/src/main/java/com/u1fukui/bbs/customview/RecyclerViewScrolledEndSubject.kt
+++ b/app/src/main/java/com/u1fukui/bbs/customview/RecyclerViewScrolledEndSubject.kt
@@ -11,9 +11,8 @@ class RecyclerViewScrolledEndSubject(private var recyclerView: RecyclerView?) {
     private val subject = PublishSubject.create<Any>()
 
     private val listener = object : RecyclerView.OnScrollListener() {
-        override fun onScrolled(recyclerView: RecyclerView?, dx: Int, dy: Int) {
-            val manager = recyclerView!!.layoutManager as LinearLayoutManager
-
+        override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+            val manager = recyclerView.layoutManager as LinearLayoutManager
             val visibleCount = recyclerView.childCount
             val totalCount = manager.itemCount
             val firstPos = manager.findFirstVisibleItemPosition()
@@ -24,7 +23,7 @@ class RecyclerViewScrolledEndSubject(private var recyclerView: RecyclerView?) {
         }
     }
 
-    internal enum class Irrelevant {
+    private enum class Irrelevant {
         INSTANCE
     }
 

--- a/app/src/main/java/com/u1fukui/bbs/ui/BaseActivity.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/BaseActivity.kt
@@ -9,21 +9,23 @@ open class BaseActivity : DaggerAppCompatActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
-            android.R.id.home -> onBackPressed()
+            android.R.id.home -> {
+                onBackPressed()
+                return true
+            }
         }
         return super.onOptionsItemSelected(item)
     }
 
     protected fun initToolbar(toolbar: Toolbar, canBack: Boolean) {
         setSupportActionBar(toolbar)
-        val bar = supportActionBar
-        if (bar != null) {
-            bar.title = toolbar.title
+        supportActionBar?.apply {
+            title = toolbar.title
             if (canBack) {
-                bar.setDisplayHomeAsUpEnabled(true)
-                bar.setDisplayShowHomeEnabled(true)
-                bar.setDisplayShowTitleEnabled(true)
-                bar.setHomeButtonEnabled(true)
+                setDisplayHomeAsUpEnabled(true)
+                setDisplayShowHomeEnabled(true)
+                setDisplayShowTitleEnabled(true)
+                setHomeButtonEnabled(true)
             }
         }
     }

--- a/app/src/main/java/com/u1fukui/bbs/ui/creation/comment/CreateCommentActivity.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/creation/comment/CreateCommentActivity.kt
@@ -16,18 +16,18 @@ import com.u1fukui.bbs.ui.Navigator
 
 class CreateCommentActivity : BaseActivity() {
 
-    private var binding: ActivityCreateCommentBinding? = null
+    private val binding by lazy {
+        DataBindingUtil.setContentView<ActivityCreateCommentBinding>(this, R.layout.activity_create_comment)
+    }
 
-    private var viewModel: CreateCommentViewModel? = null
+    private lateinit var viewModel: CreateCommentViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         viewModel = createViewModel()
-
-        binding = DataBindingUtil.setContentView(this, R.layout.activity_create_comment)
-        binding!!.viewModel = viewModel
-        initToolbar(binding!!.toolbar, true)
+        binding.viewModel = viewModel
+        initToolbar(binding.toolbar, true)
     }
 
     private fun createViewModel(): CreateCommentViewModel {
@@ -40,7 +40,7 @@ class CreateCommentActivity : BaseActivity() {
     }
 
     override fun onDestroy() {
-        binding!!.unbind()
+        binding.unbind()
         super.onDestroy()
     }
 
@@ -49,10 +49,8 @@ class CreateCommentActivity : BaseActivity() {
         private val EXTRA_THREAD = "extra.thread"
 
         @JvmStatic
-        fun createIntent(context: Context, thread: BbsThread): Intent {
-            val intent = Intent(context, CreateCommentActivity::class.java)
-            intent.putExtra(EXTRA_THREAD, thread)
-            return intent
+        fun createIntent(context: Context, thread: BbsThread) = Intent(context, CreateCommentActivity::class.java).apply {
+            putExtra(EXTRA_THREAD, thread)
         }
     }
 }

--- a/app/src/main/java/com/u1fukui/bbs/ui/creation/comment/CreateCommentViewModel.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/creation/comment/CreateCommentViewModel.kt
@@ -20,11 +20,13 @@ import io.reactivex.annotations.NonNull
 import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
 
-class CreateCommentViewModel(val bbsThread: BbsThread,
-                             val user: User,
-                             private val repository: ThreadRepository,
-                             private val navigator: Navigator,
-                             private val dialogHelper: DialogHelper) : ViewModel {
+class CreateCommentViewModel(
+        val bbsThread: BbsThread,
+        val user: User,
+        private val repository: ThreadRepository,
+        private val navigator: Navigator,
+        private val dialogHelper: DialogHelper
+) : ViewModel {
 
     val loadingVisibility = ObservableInt(View.GONE)
 

--- a/app/src/main/java/com/u1fukui/bbs/ui/creation/thread/CategoryViewModel.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/creation/thread/CategoryViewModel.kt
@@ -5,7 +5,10 @@ import android.view.View
 import com.u1fukui.bbs.model.Category
 import com.u1fukui.bbs.ui.ViewModel
 
-class CategoryViewModel(val category: Category, private val navigator: CreateThreadNavigator) : ViewModel {
+class CategoryViewModel(
+        val category: Category,
+        private val navigator: CreateThreadNavigator
+) : ViewModel {
 
     fun onClickCategory(view: View) {
         navigator.navigateToInputInfoPage(category)

--- a/app/src/main/java/com/u1fukui/bbs/ui/creation/thread/CreateThreadActivity.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/creation/thread/CreateThreadActivity.kt
@@ -2,25 +2,22 @@ package com.u1fukui.bbs.ui.creation.thread
 
 import android.databinding.DataBindingUtil
 import android.os.Bundle
-import android.support.annotation.IdRes
-
 import com.u1fukui.bbs.R
 import com.u1fukui.bbs.databinding.ActivityCreateThreadBinding
 import com.u1fukui.bbs.ui.BaseActivity
 
 class CreateThreadActivity : BaseActivity() {
 
-    private var binding: ActivityCreateThreadBinding? = null
+    private val binding by lazy {
+        DataBindingUtil.setContentView<ActivityCreateThreadBinding>(this, R.layout.activity_create_thread)
+    }
 
-    val fragmentContainerId: Int
-        @IdRes
-        get() = R.id.fragment_container
+    val fragmentContainerId = R.id.fragment_container
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = DataBindingUtil.setContentView(this, R.layout.activity_create_thread)
 
-        initToolbar(binding!!.toolbar, true)
+        initToolbar(binding.toolbar, true)
         initViews(savedInstanceState)
     }
 

--- a/app/src/main/java/com/u1fukui/bbs/ui/creation/thread/CreateThreadNavigator.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/creation/thread/CreateThreadNavigator.kt
@@ -11,7 +11,6 @@ constructor(activity: CreateThreadActivity) : Navigator(activity) {
 
     fun navigateToInputInfoPage(category: Category) {
         if (activity is CreateThreadActivity) {
-            val activity = activity
             activity.supportFragmentManager.beginTransaction()
                     .replace(activity.fragmentContainerId, InputThreadInfoFragment.newInstance(category))
                     .addToBackStack(null)

--- a/app/src/main/java/com/u1fukui/bbs/ui/creation/thread/InputThreadInfoFragment.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/creation/thread/InputThreadInfoFragment.kt
@@ -15,34 +15,32 @@ class InputThreadInfoFragment : DaggerFragment() {
     @Inject
     lateinit var viewModel: InputThreadInfoViewModel
 
-    private var binding: FragmentInputThreadInfoBinding? = null
+    internal val category by lazy {
+        arguments.getSerializable(ARG_CATEGORY) as Category
+    }
 
-    val category: Category
-        get() = arguments.getSerializable(ARG_CATEGORY) as Category
+    private lateinit var binding: FragmentInputThreadInfoBinding
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         binding = FragmentInputThreadInfoBinding.inflate(inflater, container, false)
-        binding!!.viewModel = viewModel
+        binding.viewModel = viewModel
         initViews()
 
-        return binding!!.root
+        return binding.root
     }
 
     private fun initViews() {
-        binding!!.editTextTitle.requestFocus()
+        binding.editTextTitle.requestFocus()
     }
 
     companion object {
 
         private val ARG_CATEGORY = "arg.category"
 
-        fun newInstance(category: Category): InputThreadInfoFragment {
-            val args = Bundle()
-            args.putSerializable(ARG_CATEGORY, category)
-
-            val instance = InputThreadInfoFragment()
-            instance.arguments = args
-            return instance
+        fun newInstance(category: Category) = InputThreadInfoFragment().apply {
+            arguments = Bundle().apply {
+                putSerializable(ARG_CATEGORY, category)
+            }
         }
     }
 }

--- a/app/src/main/java/com/u1fukui/bbs/ui/creation/thread/SelectCategoryFragment.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/creation/thread/SelectCategoryFragment.kt
@@ -18,16 +18,14 @@ import javax.inject.Inject
 
 class SelectCategoryFragment : DaggerFragment() {
 
-    private var binding: FragmentSelectCategoryBinding? = null
-
     @Inject
     lateinit var viewModel: SelectCategoryViewModel
 
-    private var adapter: Adapter? = null
+    private lateinit var binding: FragmentSelectCategoryBinding
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         binding = FragmentSelectCategoryBinding.inflate(inflater, container, false)
-        binding!!.viewModel = viewModel
+        binding.viewModel = viewModel
         initViews()
 
         viewModel.start()
@@ -36,31 +34,28 @@ class SelectCategoryFragment : DaggerFragment() {
     }
 
     private fun initViews() {
-        adapter = Adapter(viewModel.categoryList)
-        binding!!.recyclerView.adapter = adapter
-        binding!!.recyclerView.layoutManager = LinearLayoutManager(context)
-        binding!!.recyclerView.addItemDecoration(DividerItemDecoration(context, LinearLayoutManager.VERTICAL))
+        binding.recyclerView.apply {
+            adapter = Adapter(viewModel.categoryList)
+            layoutManager = LinearLayoutManager(context)
+            addItemDecoration(DividerItemDecoration(context, LinearLayoutManager.VERTICAL))
+        }
     }
 
     private class Adapter(list: ObservableList<CategoryViewModel>) : ObservableListRecyclerAdapter<CategoryViewModel, BindingHolder<ViewCategoryCellBinding>>(list) {
 
-        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BindingHolder<ViewCategoryCellBinding> {
-            return BindingHolder(parent.context, parent, R.layout.view_category_cell)
-        }
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = BindingHolder<ViewCategoryCellBinding>(parent.context, parent, R.layout.view_category_cell)
 
         override fun onBindViewHolder(holder: BindingHolder<ViewCategoryCellBinding>, position: Int) {
-            val viewModel = getItem(position)
-            val itemBinding = holder.binding
-            itemBinding.viewModel = viewModel
-            itemBinding.executePendingBindings()
+            holder.binding.apply {
+                viewModel = getItem(position)
+                executePendingBindings()
+            }
         }
     }
 
     companion object {
 
         @JvmStatic
-        fun newInstance(): SelectCategoryFragment {
-            return SelectCategoryFragment()
-        }
+        fun newInstance() = SelectCategoryFragment()
     }
 }

--- a/app/src/main/java/com/u1fukui/bbs/ui/creation/thread/SelectCategoryViewModel.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/creation/thread/SelectCategoryViewModel.kt
@@ -3,22 +3,17 @@ package com.u1fukui.bbs.ui.creation.thread
 
 import android.databinding.ObservableArrayList
 import android.databinding.ObservableList
-
-import com.u1fukui.bbs.model.Category
-import com.u1fukui.bbs.repository.CategoryListRepository
 import com.u1fukui.bbs.customview.ErrorView
 import com.u1fukui.bbs.helper.LoadingManager
+import com.u1fukui.bbs.model.Category
+import com.u1fukui.bbs.repository.CategoryListRepository
 import com.u1fukui.bbs.ui.ViewModel
-
-import java.util.ArrayList
-
-import javax.inject.Inject
-
 import io.reactivex.SingleObserver
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.annotations.NonNull
 import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
+import javax.inject.Inject
 
 class SelectCategoryViewModel @Inject
 constructor(private val repository: CategoryListRepository, private val navigator: CreateThreadNavigator) : ViewModel, ErrorView.ErrorViewListener {
@@ -49,10 +44,7 @@ constructor(private val repository: CategoryListRepository, private val navigato
                     }
 
                     override fun onSuccess(@NonNull categoryList: List<Category>) {
-                        val viewModelList = ArrayList<CategoryViewModel>()
-                        for (category in categoryList) {
-                            viewModelList.add(CategoryViewModel(category, navigator))
-                        }
+                        val viewModelList = categoryList.map { CategoryViewModel(it, navigator) }
 
                         this@SelectCategoryViewModel.categoryList.clear()
                         this@SelectCategoryViewModel.categoryList.addAll(viewModelList)

--- a/app/src/main/java/com/u1fukui/bbs/ui/detail/CommentViewModel.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/detail/CommentViewModel.kt
@@ -11,17 +11,11 @@ import com.u1fukui.bbs.ui.ViewModel
 
 class CommentViewModel(val comment: Comment) : ViewModel {
 
-    val createdAt: CharSequence
+    val createdAt = DateFormat.format(DATE_FORMAT_PATTERN, comment.createdAt)!!
 
-    val isLiked: ObservableBoolean
+    val isLiked = ObservableBoolean(comment.isLiked)
 
-    val likeCount: ObservableInt
-
-    init {
-        this.createdAt = DateFormat.format(DATE_FORMAT_PATTERN, comment.createdAt)
-        this.isLiked = ObservableBoolean(comment.isLiked)
-        this.likeCount = ObservableInt(comment.likeCount)
-    }
+    val likeCount = ObservableInt(comment.likeCount)
 
     fun onClickComment(view: View) {
         //TODO: 実装
@@ -36,7 +30,7 @@ class CommentViewModel(val comment: Comment) : ViewModel {
     }
 
     override fun destroy() {
-
+        // nop
     }
 
     companion object {

--- a/app/src/main/java/com/u1fukui/bbs/ui/detail/ThreadDetailActivity.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/detail/ThreadDetailActivity.kt
@@ -28,64 +28,57 @@ class ThreadDetailActivity : BaseActivity() {
     @Inject
     lateinit var repository: ThreadRepository
 
-    private var binding: ActivityThreadDetailBinding? = null
+    private val binding by lazy {
+        DataBindingUtil.setContentView<ActivityThreadDetailBinding>(this, R.layout.activity_thread_detail)
+    }
 
-    private var adapter: Adapter? = null
-
-    private var viewModel: ThreadDetailViewModel? = null
+    private lateinit var viewModel: ThreadDetailViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = DataBindingUtil.setContentView(this, R.layout.activity_thread_detail)
 
         val thread = intent.getSerializableExtra(EXTRA_THREAD) as BbsThread
         viewModel = ThreadDetailViewModel(thread, repository, navigator)
-        binding!!.viewModel = viewModel
-        initToolbar(binding!!.toolbar, true)
+        binding.viewModel = viewModel
+        initToolbar(binding.toolbar, true)
 
         initViews()
-        viewModel!!.start()
+        viewModel.start()
     }
 
     private fun initViews() {
-        adapter = Adapter(viewModel!!.commentViewModelList)
-        binding!!.recyclerView.adapter = adapter
-        binding!!.recyclerView.layoutManager = LinearLayoutManager(this)
-        binding!!.recyclerView.addItemDecoration(DividerItemDecoration(this, LinearLayoutManager.VERTICAL))
+        binding.recyclerView.apply {
+            adapter = Adapter(viewModel.commentViewModelList)
+            layoutManager = LinearLayoutManager(context)
+            addItemDecoration(DividerItemDecoration(context, LinearLayoutManager.VERTICAL))
+        }
     }
 
     override fun onDestroy() {
-        viewModel!!.destroy()
-        binding!!.unbind()
+        viewModel.destroy()
+        binding.unbind()
         super.onDestroy()
     }
 
     private class Adapter(list: ObservableList<CommentViewModel>) : ObservableListRecyclerAdapter<CommentViewModel, BindingHolder<ViewCommentCellBinding>>(list) {
 
-        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BindingHolder<ViewCommentCellBinding> {
-            return BindingHolder(parent.context, parent, R.layout.view_comment_cell)
-        }
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = BindingHolder<ViewCommentCellBinding>(parent.context, parent, R.layout.view_comment_cell)
 
         override fun onBindViewHolder(holder: BindingHolder<ViewCommentCellBinding>, position: Int) {
-            val viewModel = getItem(position)
-            val itemBinding = holder.binding
-            itemBinding.viewModel = viewModel
-            itemBinding.executePendingBindings()
+            holder.binding.apply {
+                viewModel = getItem(position)
+                executePendingBindings()
+            }
         }
     }
 
     companion object {
 
-        @JvmStatic
-        val TAG = ThreadDetailActivity::class.java.simpleName
-
         private const val EXTRA_THREAD = "extra.thread"
 
         @JvmStatic
-        fun createIntent(context: Context, thread: BbsThread): Intent {
-            val intent = Intent(context, ThreadDetailActivity::class.java)
-            intent.putExtra(EXTRA_THREAD, thread)
-            return intent
+        fun createIntent(context: Context, thread: BbsThread) = Intent(context, ThreadDetailActivity::class.java).apply {
+            putExtra(EXTRA_THREAD, thread)
         }
     }
 }

--- a/app/src/main/java/com/u1fukui/bbs/ui/detail/ThreadDetailViewModel.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/detail/ThreadDetailViewModel.kt
@@ -4,16 +4,12 @@ import android.databinding.ObservableArrayList
 import android.databinding.ObservableBoolean
 import android.databinding.ObservableList
 import android.view.View
-
 import com.u1fukui.bbs.customview.ErrorView
 import com.u1fukui.bbs.helper.LoadingManager
 import com.u1fukui.bbs.model.BbsThread
 import com.u1fukui.bbs.model.Comment
 import com.u1fukui.bbs.repository.ThreadRepository
 import com.u1fukui.bbs.ui.ViewModel
-
-import java.util.ArrayList
-
 import io.reactivex.SingleObserver
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.annotations.NonNull
@@ -23,7 +19,8 @@ import io.reactivex.schedulers.Schedulers
 class ThreadDetailViewModel(//region DataBinding
         val bbsThread: BbsThread,
         private val repository: ThreadRepository,
-        private val navigator: ThreadDetailNavigator) : ViewModel, ErrorView.ErrorViewListener {
+        private val navigator: ThreadDetailNavigator
+) : ViewModel, ErrorView.ErrorViewListener {
 
     val refreshing = ObservableBoolean(false)
 
@@ -66,10 +63,7 @@ class ThreadDetailViewModel(//region DataBinding
                     }
 
                     override fun onSuccess(@NonNull bbsComments: List<Comment>) {
-                        val viewModelList = ArrayList<CommentViewModel>()
-                        for (comment in bbsComments) {
-                            viewModelList.add(CommentViewModel(comment))
-                        }
+                        val viewModelList = bbsComments.map { CommentViewModel(it) }
                         renderCommentList(viewModelList)
                     }
 

--- a/app/src/main/java/com/u1fukui/bbs/ui/main/BaseThreadListFragment.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/main/BaseThreadListFragment.kt
@@ -87,7 +87,7 @@ abstract class BaseThreadListFragment : Fragment() {
 
     private class Adapter(list: ObservableList<ThreadViewModel>) : ObservableListRecyclerAdapter<ThreadViewModel, BindingHolder<ViewThreadCellBinding>>(list) {
 
-        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BindingHolder<ViewThreadCellBinding> = BindingHolder(parent.context, parent, R.layout.view_thread_cell)
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = BindingHolder<ViewThreadCellBinding>(parent.context, parent, R.layout.view_thread_cell)
 
         override fun onBindViewHolder(holder: BindingHolder<ViewThreadCellBinding>, position: Int) {
             holder.binding.apply {

--- a/app/src/main/java/com/u1fukui/bbs/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/main/MainActivity.kt
@@ -15,10 +15,12 @@ import javax.inject.Inject
 
 class MainActivity : BaseActivity() {
 
+    private val binding by lazy {
+        DataBindingUtil.setContentView<ActivityMainBinding>(this, R.layout.activity_main)
+    }
+
     @Inject
     lateinit var navigator: MainNavigator
-
-    private lateinit var binding: ActivityMainBinding
 
     private var homeFragment: Fragment? = null
 
@@ -26,8 +28,6 @@ class MainActivity : BaseActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = DataBindingUtil.setContentView(this, R.layout.activity_main)
-
         initToolbar(binding.toolbar, false)
         initViews()
         initFragments(savedInstanceState)
@@ -67,14 +67,8 @@ class MainActivity : BaseActivity() {
 
     private fun initFragments(savedInstanceState: Bundle?) {
         val manager = supportFragmentManager
-        homeFragment = manager.findFragmentByTag(HomeFragment.TAG)
-        myPageFragment = manager.findFragmentByTag(MyPageFragment.TAG)
-        if (homeFragment == null) {
-            homeFragment = HomeFragment.newInstance()
-        }
-        if (myPageFragment == null) {
-            myPageFragment = MyPageFragment.newInstance()
-        }
+        homeFragment = manager.findFragmentByTag(HomeFragment.TAG)?: HomeFragment.newInstance()
+        myPageFragment = manager.findFragmentByTag(MyPageFragment.TAG)?: MyPageFragment.newInstance()
         if (savedInstanceState == null) {
             switchFragment(homeFragment, HomeFragment.TAG)
         }

--- a/app/src/main/java/com/u1fukui/bbs/ui/main/ThreadListViewModel.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/main/ThreadListViewModel.kt
@@ -14,9 +14,11 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.annotations.NonNull
 import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
-import java.util.*
 
-class ThreadListViewModel(private val repository: ThreadListRepository, private val navigator: ThreadListNavigator) : ViewModel, ErrorView.ErrorViewListener {
+class ThreadListViewModel(
+        private val repository: ThreadListRepository,
+        private val navigator: ThreadListNavigator
+) : ViewModel, ErrorView.ErrorViewListener {
 
     //region DataBinding
     val loadingManager = LoadingManager()
@@ -65,10 +67,7 @@ class ThreadListViewModel(private val repository: ThreadListRepository, private 
                     }
 
                     override fun onSuccess(@NonNull response: ThreadListResponse) {
-                        val viewModelList = ArrayList<ThreadViewModel>()
-                        for (thread in response.threadList) {
-                            viewModelList.add(ThreadViewModel(navigator, thread))
-                        }
+                        val viewModelList = response.threadList.map { ThreadViewModel(navigator, it) }
 
                         isThreadListCompleted = response.isCompleted
                         if (lastId == 0L) {

--- a/app/src/main/java/com/u1fukui/bbs/ui/main/ThreadViewModel.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/main/ThreadViewModel.kt
@@ -6,13 +6,12 @@ import android.view.View
 import com.u1fukui.bbs.model.BbsThread
 import com.u1fukui.bbs.ui.ViewModel
 
-class ThreadViewModel(private val navigator: ThreadListNavigator, val bbsThread: BbsThread) : ViewModel {
+class ThreadViewModel(
+        private val navigator: ThreadListNavigator,
+        val bbsThread: BbsThread
+) : ViewModel {
 
-    val updatedAt: CharSequence
-
-    init {
-        this.updatedAt = DateFormat.format(DATE_FORMAT_PATTERN, bbsThread.updatedAt)
-    }
+    val updatedAt : CharSequence? = DateFormat.format(DATE_FORMAT_PATTERN, bbsThread.updatedAt)
 
     fun onClickThread(view: View) {
         navigator.navigateToThreadDetailPage(bbsThread)

--- a/app/src/main/java/com/u1fukui/bbs/ui/main/home/CategoryThreadListFragment.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/main/home/CategoryThreadListFragment.kt
@@ -1,30 +1,22 @@
 package com.u1fukui.bbs.ui.main.home
 
 import android.os.Bundle
-
 import com.u1fukui.bbs.model.Category
 import com.u1fukui.bbs.repository.CategoryThreadListRepository
-import com.u1fukui.bbs.repository.ThreadListRepository
 import com.u1fukui.bbs.ui.main.BaseThreadListFragment
 
 class CategoryThreadListFragment : BaseThreadListFragment() {
 
-    protected override val repository: ThreadListRepository
-        get() = CategoryThreadListRepository()
+    override val repository = CategoryThreadListRepository()
 
     companion object {
 
-        val TAG = CategoryThreadListFragment::class.java.simpleName
-
         private val ARG_CATEGORY = "arg.categroy"
 
-        fun newInstance(category: Category): CategoryThreadListFragment {
-            val args = Bundle()
-            args.putSerializable(ARG_CATEGORY, category)
-
-            val instance = CategoryThreadListFragment()
-            instance.arguments = args
-            return instance
+        fun newInstance(category: Category) =  CategoryThreadListFragment().apply {
+            arguments = Bundle().apply {
+                putSerializable(ARG_CATEGORY, category)
+            }
         }
     }
 }

--- a/app/src/main/java/com/u1fukui/bbs/ui/main/home/HomeFragment.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/main/home/HomeFragment.kt
@@ -3,7 +3,6 @@ package com.u1fukui.bbs.ui.main.home
 import android.databinding.ObservableList
 import android.os.Bundle
 import android.support.design.widget.TabLayout
-import android.support.v4.app.Fragment
 import android.support.v4.app.FragmentManager
 import android.support.v4.app.FragmentPagerAdapter
 import android.view.LayoutInflater
@@ -19,30 +18,35 @@ class HomeFragment : DaggerFragment() {
     @Inject
     lateinit var viewModel: HomeViewModel
 
-    private var binding: FragmentHomeBinding? = null
+    private lateinit var binding: FragmentHomeBinding
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         binding = FragmentHomeBinding.inflate(inflater, container, false)
-        binding!!.viewModel = viewModel
+        binding.viewModel = viewModel
         initViews()
 
         viewModel.start()
 
-        return binding!!.root
+        return binding.root
     }
 
     private fun initViews() {
-        binding!!.viewPager.adapter = HomePagerAdapter(childFragmentManager, viewModel.categoryList)
-        binding!!.tabLayout.tabMode = TabLayout.MODE_SCROLLABLE
-        binding!!.tabLayout.setupWithViewPager(binding!!.viewPager)
+        binding.apply {
+            viewPager.adapter = HomePagerAdapter(childFragmentManager, viewModel!!.categoryList)
+            tabLayout.tabMode = TabLayout.MODE_SCROLLABLE
+            tabLayout.setupWithViewPager(binding.viewPager)
+        }
     }
 
     override fun onDestroyView() {
-        binding!!.unbind()
+        binding.unbind()
         super.onDestroyView()
     }
 
-    private class HomePagerAdapter(manager: FragmentManager, private val categoryList: ObservableList<Category>) : FragmentPagerAdapter(manager) {
+    private class HomePagerAdapter(
+            manager: FragmentManager,
+            private val categoryList: ObservableList<Category>
+    ) : FragmentPagerAdapter(manager) {
 
         init {
             this.categoryList.addOnListChangedCallback(object : ObservableList.OnListChangedCallback<ObservableList<Category>>() {
@@ -68,17 +72,11 @@ class HomeFragment : DaggerFragment() {
             })
         }
 
-        override fun getItem(position: Int): Fragment {
-            return CategoryThreadListFragment.newInstance(categoryList[position])
-        }
+        override fun getItem(position: Int) = CategoryThreadListFragment.newInstance(categoryList[position])
 
-        override fun getCount(): Int {
-            return categoryList.size
-        }
+        override fun getCount() = categoryList.size
 
-        override fun getPageTitle(position: Int): CharSequence {
-            return categoryList[position].name
-        }
+        override fun getPageTitle(position: Int) = categoryList[position].name
     }
 
     companion object {
@@ -87,8 +85,6 @@ class HomeFragment : DaggerFragment() {
         val TAG = HomeFragment::class.java.simpleName
 
         @JvmStatic
-        fun newInstance(): HomeFragment {
-            return HomeFragment()
-        }
+        fun newInstance() = HomeFragment()
     }
 }

--- a/app/src/main/java/com/u1fukui/bbs/ui/main/home/HomeViewModel.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/main/home/HomeViewModel.kt
@@ -3,24 +3,24 @@ package com.u1fukui.bbs.ui.main.home
 import android.databinding.ObservableArrayList
 import android.databinding.ObservableList
 import android.view.View
-
-import com.u1fukui.bbs.model.Category
-import com.u1fukui.bbs.repository.CategoryListRepository
 import com.u1fukui.bbs.customview.ErrorView
 import com.u1fukui.bbs.helper.LoadingManager
-import com.u1fukui.bbs.ui.main.MainNavigator
+import com.u1fukui.bbs.model.Category
+import com.u1fukui.bbs.repository.CategoryListRepository
 import com.u1fukui.bbs.ui.ViewModel
-
-import javax.inject.Inject
-
+import com.u1fukui.bbs.ui.main.MainNavigator
 import io.reactivex.SingleObserver
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.annotations.NonNull
 import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
+import javax.inject.Inject
 
 class HomeViewModel @Inject
-constructor(private val repository: CategoryListRepository, private val navigator: MainNavigator) : ViewModel, ErrorView.ErrorViewListener {
+constructor(
+        private val repository: CategoryListRepository,
+        private val navigator: MainNavigator
+) : ViewModel, ErrorView.ErrorViewListener {
 
     val loadingManager = LoadingManager()
 

--- a/app/src/main/java/com/u1fukui/bbs/ui/main/mypage/FavoriteThreadListFragment.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/main/mypage/FavoriteThreadListFragment.kt
@@ -1,20 +1,16 @@
 package com.u1fukui.bbs.ui.main.mypage
 
 import com.u1fukui.bbs.repository.FavoriteThreadListRepository
-import com.u1fukui.bbs.repository.ThreadListRepository
 import com.u1fukui.bbs.ui.main.BaseThreadListFragment
 
 class FavoriteThreadListFragment : BaseThreadListFragment() {
 
-    protected override val repository: ThreadListRepository
-        get() = FavoriteThreadListRepository()
+    override val repository = FavoriteThreadListRepository()
 
     companion object {
 
         @JvmStatic
-        fun newInstance(): FavoriteThreadListFragment {
-            return FavoriteThreadListFragment()
-        }
+        fun newInstance() = FavoriteThreadListFragment()
     }
 
 }

--- a/app/src/main/java/com/u1fukui/bbs/ui/main/mypage/HistoryThreadListFragment.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/main/mypage/HistoryThreadListFragment.kt
@@ -1,19 +1,15 @@
 package com.u1fukui.bbs.ui.main.mypage
 
 import com.u1fukui.bbs.repository.HistoryThreadListRepository
-import com.u1fukui.bbs.repository.ThreadListRepository
 import com.u1fukui.bbs.ui.main.BaseThreadListFragment
 
 class HistoryThreadListFragment : BaseThreadListFragment() {
 
-    protected override val repository: ThreadListRepository
-        get() = HistoryThreadListRepository()
+    override val repository = HistoryThreadListRepository()
 
     companion object {
 
         @JvmStatic
-        fun newInstance(): HistoryThreadListFragment {
-            return HistoryThreadListFragment()
-        }
+        fun newInstance() = HistoryThreadListFragment()
     }
 }

--- a/app/src/main/java/com/u1fukui/bbs/ui/main/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/main/mypage/MyPageFragment.kt
@@ -13,23 +13,25 @@ import com.u1fukui.bbs.databinding.FragmentMypageBinding
 
 class MyPageFragment : Fragment() {
 
-    private var binding: FragmentMypageBinding? = null
+    private lateinit var binding: FragmentMypageBinding
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         binding = FragmentMypageBinding.inflate(inflater, container, false)
         initViews()
 
-        return binding!!.root
+        return binding.root
     }
 
     private fun initViews() {
-        binding!!.tabLayout.tabMode = TabLayout.MODE_FIXED
-        binding!!.viewPager.adapter = MyPagePagerAdapter(childFragmentManager)
-        binding!!.tabLayout.setupWithViewPager(binding!!.viewPager)
+        binding.apply {
+            viewPager.adapter = MyPagePagerAdapter(childFragmentManager)
+            tabLayout.tabMode = TabLayout.MODE_FIXED
+            tabLayout.setupWithViewPager(viewPager)
+        }
     }
 
     override fun onDestroyView() {
-        binding!!.unbind()
+        binding.unbind()
         super.onDestroyView()
     }
 
@@ -37,24 +39,16 @@ class MyPageFragment : Fragment() {
 
         internal enum class Tab {
             FAVORITE {
+                //TODO: Apply resource string
+                override val title = "Favorite"
 
-                override//TODO: Apply resource string
-                val title: String
-                    get() = "Favorite"
-
-                override fun createInsatance(): Fragment {
-                    return FavoriteThreadListFragment.newInstance()
-                }
+                override fun createInsatance() = FavoriteThreadListFragment.newInstance()
             },
             HISTORY {
+                //TODO: Apply resource string
+                override val title = "History"
 
-                override//TODO: Apply resource string
-                val title: String
-                    get() = "History"
-
-                override fun createInsatance(): Fragment {
-                    return HistoryThreadListFragment.newInstance()
-                }
+                override fun createInsatance() = HistoryThreadListFragment.newInstance()
             };
 
             internal abstract val title: String
@@ -62,19 +56,11 @@ class MyPageFragment : Fragment() {
             internal abstract fun createInsatance(): Fragment
         }
 
-        override fun getItem(position: Int): Fragment {
-            val tab = Tab.values()[position]
-            return tab.createInsatance()
-        }
+        override fun getItem(position: Int) = Tab.values()[position].createInsatance()
 
-        override fun getCount(): Int {
-            return Tab.values().size
-        }
+        override fun getCount() = Tab.values().size
 
-        override fun getPageTitle(position: Int): CharSequence {
-            val tab = Tab.values()[position]
-            return tab.title
-        }
+        override fun getPageTitle(position: Int) = Tab.values()[position].title
     }
 
     companion object {
@@ -83,8 +69,6 @@ class MyPageFragment : Fragment() {
         val TAG = MyPageFragment::class.java.simpleName
 
         @JvmStatic
-        fun newInstance(): MyPageFragment {
-            return MyPageFragment()
-        }
+        fun newInstance() =  MyPageFragment()
     }
 }

--- a/app/src/main/java/com/u1fukui/bbs/ui/notification/NotificationListActivity.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/notification/NotificationListActivity.kt
@@ -20,45 +20,43 @@ class NotificationListActivity : BaseActivity() {
     @Inject
     lateinit var viewModel: NotificationListViewModel
 
-    private var binding: ActivityNotificationListBinding? = null
-
-    private var adapter: Adapter? = null
+    private val binding by lazy {
+        DataBindingUtil.setContentView<ActivityNotificationListBinding>(this, R.layout.activity_notification_list)
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = DataBindingUtil.setContentView(this, R.layout.activity_notification_list)
-        binding!!.viewModel = viewModel
+        binding.viewModel = viewModel
 
-        initToolbar(binding!!.toolbar, true)
+        initToolbar(binding.toolbar, true)
         initViews()
 
         viewModel.start()
     }
 
     private fun initViews() {
-        adapter = Adapter(viewModel.notificationViewModelList)
-        binding!!.recyclerView.adapter = adapter
-        binding!!.recyclerView.layoutManager = LinearLayoutManager(this)
-        binding!!.recyclerView.addItemDecoration(DividerItemDecoration(this, LinearLayoutManager.VERTICAL))
+        binding.recyclerView.apply {
+            adapter = Adapter(viewModel.notificationViewModelList)
+            layoutManager = LinearLayoutManager(context)
+            addItemDecoration(DividerItemDecoration(context, LinearLayoutManager.VERTICAL))
+        }
     }
 
     override fun onDestroy() {
         viewModel.destroy()
-        binding!!.unbind()
+        binding.unbind()
         super.onDestroy()
     }
 
     private class Adapter(list: ObservableList<NotificationViewModel>) : ObservableListRecyclerAdapter<NotificationViewModel, BindingHolder<ViewNotificationCellBinding>>(list) {
 
-        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BindingHolder<ViewNotificationCellBinding> {
-            return BindingHolder(parent.context, parent, R.layout.view_notification_cell)
-        }
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = BindingHolder<ViewNotificationCellBinding>(parent.context, parent, R.layout.view_notification_cell)
 
         override fun onBindViewHolder(holder: BindingHolder<ViewNotificationCellBinding>, position: Int) {
-            val viewModel = getItem(position)
-            val itemBinding = holder.binding
-            itemBinding.viewModel = viewModel
-            itemBinding.executePendingBindings()
+            holder.binding.apply {
+                viewModel = getItem(position)
+                executePendingBindings()
+            }
         }
     }
 }

--- a/app/src/main/java/com/u1fukui/bbs/ui/notification/NotificationListViewModel.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/notification/NotificationListViewModel.kt
@@ -2,22 +2,17 @@ package com.u1fukui.bbs.ui.notification
 
 import android.databinding.ObservableArrayList
 import android.databinding.ObservableList
-
 import com.u1fukui.bbs.customview.ErrorView
 import com.u1fukui.bbs.helper.LoadingManager
 import com.u1fukui.bbs.model.Notification
 import com.u1fukui.bbs.repository.NotificationListRepository
 import com.u1fukui.bbs.ui.ViewModel
-
-import java.util.ArrayList
-
-import javax.inject.Inject
-
 import io.reactivex.SingleObserver
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.annotations.NonNull
 import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
+import javax.inject.Inject
 
 class NotificationListViewModel @Inject
 constructor(private val repository: NotificationListRepository) : ViewModel, ErrorView.ErrorViewListener {
@@ -48,10 +43,7 @@ constructor(private val repository: NotificationListRepository) : ViewModel, Err
                     }
 
                     override fun onSuccess(@NonNull notificationList: List<Notification>) {
-                        val viewModelList = ArrayList<NotificationViewModel>()
-                        for (notification in notificationList) {
-                            viewModelList.add(NotificationViewModel(notification))
-                        }
+                        val viewModelList = notificationList.map { NotificationViewModel(it) }
                         renderNotificationList(viewModelList)
 
                     }

--- a/app/src/main/java/com/u1fukui/bbs/ui/notification/NotificationViewModel.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/notification/NotificationViewModel.kt
@@ -9,11 +9,7 @@ import com.u1fukui.bbs.ui.ViewModel
 
 class NotificationViewModel(val notification: Notification) : ViewModel {
 
-    val createdAt: CharSequence
-
-    init {
-        this.createdAt = DateFormat.format(DATE_FORMAT_PATTERN, notification.createdAt)
-    }
+    val createdAt = DateFormat.format(DATE_FORMAT_PATTERN, notification.createdAt)!!
 
     fun onClickNotification(view: View) {
         //TODO: 実装


### PR DESCRIPTION
ui パッケージのクラスを、Kotlin の機能を使ってなるべくシンプルになるよう整理しta.

## 主にやったこと
- https://github.com/u1fukui/bbs-android/commit/63b551b6475ab9e934b701ab6a4e6269278a859a
  - init を使う必要がない初期化処理は、変数宣言の所に直接書く
- https://github.com/u1fukui/bbs-android/commit/9a96e7b35bc721f8c7383a689b7eac9849830eb9
  - custom view のコンストラクタは複数書く必要がなくなった
- https://github.com/u1fukui/bbs-android/commit/9aa852752f7fe4203d7a5abcb8812dc8aaba073c
  - Activity の場合、binding は `val` で宣言し、 `by lazy` を使って初期化する (1回しか初期化されないので)
  - null の場合はこの処理をする、みたいなのは `?:` を使って書く
- https://github.com/u1fukui/bbs-android/commit/a635f99464fe80fc9ab2f89c072d2cc85395e18d
  - Fragment の場合、 binding は `var` で宣言し、`lateinit` を使って初期化する (`onCreateView()`が複数回呼ばれる可能性があるので)
  - 返り値があるメソッドで中身が1つの式しかない場合は、`{}` で括らず `=` で書く
  - `apply` はめちゃくちゃ便利なので活用する。(`Fragment.newInstance()` 周りや、view の初期化処理でよく使う)
- とりあえず現時点で分かっているコツは以上。これらを各クラスに適用するだけで割りとシンプルになった気がする。