### PR TITLE
Apply ThreadListApi to ThreadListRepositories of favorite and history.

### DIFF
--- a/app/src/main/java/com/u1fukui/bbs/di/InjectorsModule.kt
+++ b/app/src/main/java/com/u1fukui/bbs/di/InjectorsModule.kt
@@ -14,22 +14,22 @@ import dagger.android.ContributesAndroidInjector
 internal abstract class InjectorsModule {
 
     @ActivityScope
-    @ContributesAndroidInjector(modules = arrayOf(MainActivityModule::class, MainActivityModule.BindModule::class))
+    @ContributesAndroidInjector(modules = arrayOf(ActivityModule::class, MainActivityModule::class, MainActivityModule.BindModule::class))
     internal abstract fun mainActivity(): MainActivity
 
     @ActivityScope
-    @ContributesAndroidInjector(modules = arrayOf(CreateThreadActivityModule::class, CreateThreadActivityModule.BindModule::class))
+    @ContributesAndroidInjector(modules = arrayOf(ActivityModule::class, CreateThreadActivityModule::class, CreateThreadActivityModule.BindModule::class))
     internal abstract fun createThreadActivity(): CreateThreadActivity
 
     @ActivityScope
-    @ContributesAndroidInjector(modules = arrayOf(ThreadDetailActivityModule::class))
+    @ContributesAndroidInjector(modules = arrayOf(ActivityModule::class, ThreadDetailActivityModule::class))
     internal abstract fun threadDetailActivity(): ThreadDetailActivity
 
     @ActivityScope
-    @ContributesAndroidInjector(modules = arrayOf(CreateCommentActivityModule::class))
+    @ContributesAndroidInjector(modules = arrayOf(ActivityModule::class, CreateCommentActivityModule::class))
     internal abstract fun createCommentActivity(): CreateCommentActivity
 
     @ActivityScope
-    @ContributesAndroidInjector(modules = arrayOf(NotificationListActivityModule::class))
+    @ContributesAndroidInjector(modules = arrayOf(ActivityModule::class, NotificationListActivityModule::class))
     internal abstract fun notificationListActivity(): NotificationListActivity
 }

--- a/app/src/main/java/com/u1fukui/bbs/di/activity/ActivityModule.kt
+++ b/app/src/main/java/com/u1fukui/bbs/di/activity/ActivityModule.kt
@@ -1,0 +1,6 @@
+package com.u1fukui.bbs.di.activity
+
+import dagger.Module
+
+@Module
+class ActivityModule

--- a/app/src/main/java/com/u1fukui/bbs/di/activity/CreateThreadActivityModule.kt
+++ b/app/src/main/java/com/u1fukui/bbs/di/activity/CreateThreadActivityModule.kt
@@ -1,7 +1,7 @@
 package com.u1fukui.bbs.di.activity
 
+import com.u1fukui.bbs.di.fragment.FragmentModule
 import com.u1fukui.bbs.di.fragment.InputThreadInfoFragmentModule
-import com.u1fukui.bbs.di.fragment.SelectCategoryFragmentModule
 import com.u1fukui.bbs.di.scope.FragmentScope
 import com.u1fukui.bbs.ui.creation.thread.InputThreadInfoFragment
 import com.u1fukui.bbs.ui.creation.thread.SelectCategoryFragment
@@ -16,11 +16,11 @@ class CreateThreadActivityModule {
     abstract inner class BindModule {
 
         @FragmentScope
-        @ContributesAndroidInjector(modules = arrayOf(SelectCategoryFragmentModule::class))
+        @ContributesAndroidInjector(modules = arrayOf(FragmentModule::class))
         internal abstract fun selectCategoryFragment(): SelectCategoryFragment
 
         @FragmentScope
-        @ContributesAndroidInjector(modules = arrayOf(InputThreadInfoFragmentModule::class))
+        @ContributesAndroidInjector(modules = arrayOf(FragmentModule::class, InputThreadInfoFragmentModule::class))
         internal abstract fun inputThreadInfoFragment(): InputThreadInfoFragment
     }
 }

--- a/app/src/main/java/com/u1fukui/bbs/di/activity/MainActivityModule.kt
+++ b/app/src/main/java/com/u1fukui/bbs/di/activity/MainActivityModule.kt
@@ -1,10 +1,14 @@
 package com.u1fukui.bbs.di.activity
 
 import com.u1fukui.bbs.di.fragment.CategoryThreadListFragmentModule
+import com.u1fukui.bbs.di.fragment.FavoriteThreadListFragmentModule
+import com.u1fukui.bbs.di.fragment.HistoryThreadListFragmentModule
 import com.u1fukui.bbs.di.fragment.HomeFragmentModule
 import com.u1fukui.bbs.di.scope.FragmentScope
 import com.u1fukui.bbs.ui.main.home.CategoryThreadListFragment
 import com.u1fukui.bbs.ui.main.home.HomeFragment
+import com.u1fukui.bbs.ui.main.mypage.FavoriteThreadListFragment
+import com.u1fukui.bbs.ui.main.mypage.HistoryThreadListFragment
 
 import dagger.Module
 import dagger.android.ContributesAndroidInjector
@@ -22,5 +26,13 @@ class MainActivityModule {
         @FragmentScope
         @ContributesAndroidInjector(modules = arrayOf(CategoryThreadListFragmentModule::class))
         internal abstract fun categoryThreadListFragemnt(): CategoryThreadListFragment
+
+        @FragmentScope
+        @ContributesAndroidInjector(modules = arrayOf(FavoriteThreadListFragmentModule::class))
+        internal abstract fun favoriteThreadListFragment(): FavoriteThreadListFragment
+
+        @FragmentScope
+        @ContributesAndroidInjector(modules = arrayOf(HistoryThreadListFragmentModule::class))
+        internal abstract fun historyThreadListFragment(): HistoryThreadListFragment
     }
 }

--- a/app/src/main/java/com/u1fukui/bbs/di/activity/MainActivityModule.kt
+++ b/app/src/main/java/com/u1fukui/bbs/di/activity/MainActivityModule.kt
@@ -1,9 +1,6 @@
 package com.u1fukui.bbs.di.activity
 
-import com.u1fukui.bbs.di.fragment.CategoryThreadListFragmentModule
-import com.u1fukui.bbs.di.fragment.FavoriteThreadListFragmentModule
-import com.u1fukui.bbs.di.fragment.HistoryThreadListFragmentModule
-import com.u1fukui.bbs.di.fragment.HomeFragmentModule
+import com.u1fukui.bbs.di.fragment.FragmentModule
 import com.u1fukui.bbs.di.scope.FragmentScope
 import com.u1fukui.bbs.ui.main.home.CategoryThreadListFragment
 import com.u1fukui.bbs.ui.main.home.HomeFragment
@@ -20,19 +17,19 @@ class MainActivityModule {
     abstract inner class BindModule {
 
         @FragmentScope
-        @ContributesAndroidInjector(modules = arrayOf(HomeFragmentModule::class))
+        @ContributesAndroidInjector(modules = arrayOf(FragmentModule::class))
         internal abstract fun homeFragment(): HomeFragment
 
         @FragmentScope
-        @ContributesAndroidInjector(modules = arrayOf(CategoryThreadListFragmentModule::class))
+        @ContributesAndroidInjector(modules = arrayOf(FragmentModule::class))
         internal abstract fun categoryThreadListFragemnt(): CategoryThreadListFragment
 
         @FragmentScope
-        @ContributesAndroidInjector(modules = arrayOf(FavoriteThreadListFragmentModule::class))
+        @ContributesAndroidInjector(modules = arrayOf(FragmentModule::class))
         internal abstract fun favoriteThreadListFragment(): FavoriteThreadListFragment
 
         @FragmentScope
-        @ContributesAndroidInjector(modules = arrayOf(HistoryThreadListFragmentModule::class))
+        @ContributesAndroidInjector(modules = arrayOf(FragmentModule::class))
         internal abstract fun historyThreadListFragment(): HistoryThreadListFragment
     }
 }

--- a/app/src/main/java/com/u1fukui/bbs/di/fragment/CategoryThreadListFragmentModule.kt
+++ b/app/src/main/java/com/u1fukui/bbs/di/fragment/CategoryThreadListFragmentModule.kt
@@ -1,6 +1,0 @@
-package com.u1fukui.bbs.di.fragment
-
-import dagger.Module
-
-@Module
-class CategoryThreadListFragmentModule

--- a/app/src/main/java/com/u1fukui/bbs/di/fragment/FavoriteThreadListFragmentModule.kt
+++ b/app/src/main/java/com/u1fukui/bbs/di/fragment/FavoriteThreadListFragmentModule.kt
@@ -1,6 +1,0 @@
-package com.u1fukui.bbs.di.fragment
-
-import dagger.Module
-
-@Module
-class FavoriteThreadListFragmentModule

--- a/app/src/main/java/com/u1fukui/bbs/di/fragment/FavoriteThreadListFragmentModule.kt
+++ b/app/src/main/java/com/u1fukui/bbs/di/fragment/FavoriteThreadListFragmentModule.kt
@@ -1,0 +1,6 @@
+package com.u1fukui.bbs.di.fragment
+
+import dagger.Module
+
+@Module
+class FavoriteThreadListFragmentModule

--- a/app/src/main/java/com/u1fukui/bbs/di/fragment/FragmentModule.kt
+++ b/app/src/main/java/com/u1fukui/bbs/di/fragment/FragmentModule.kt
@@ -3,4 +3,4 @@ package com.u1fukui.bbs.di.fragment
 import dagger.Module
 
 @Module
-class SelectCategoryFragmentModule
+class FragmentModule

--- a/app/src/main/java/com/u1fukui/bbs/di/fragment/HistoryThreadListFragmentModule.kt
+++ b/app/src/main/java/com/u1fukui/bbs/di/fragment/HistoryThreadListFragmentModule.kt
@@ -1,0 +1,6 @@
+package com.u1fukui.bbs.di.fragment
+
+import dagger.Module
+
+@Module
+class HistoryThreadListFragmentModule

--- a/app/src/main/java/com/u1fukui/bbs/di/fragment/HistoryThreadListFragmentModule.kt
+++ b/app/src/main/java/com/u1fukui/bbs/di/fragment/HistoryThreadListFragmentModule.kt
@@ -1,6 +1,0 @@
-package com.u1fukui.bbs.di.fragment
-
-import dagger.Module
-
-@Module
-class HistoryThreadListFragmentModule

--- a/app/src/main/java/com/u1fukui/bbs/di/fragment/HomeFragmentModule.kt
+++ b/app/src/main/java/com/u1fukui/bbs/di/fragment/HomeFragmentModule.kt
@@ -1,6 +1,0 @@
-package com.u1fukui.bbs.di.fragment
-
-import dagger.Module
-
-@Module
-class HomeFragmentModule

--- a/app/src/main/java/com/u1fukui/bbs/repository/FavoriteThreadListRepository.kt
+++ b/app/src/main/java/com/u1fukui/bbs/repository/FavoriteThreadListRepository.kt
@@ -1,31 +1,38 @@
 package com.u1fukui.bbs.repository
 
 
-import android.os.SystemClock
-
+import com.u1fukui.bbs.api.ThreadListApi
 import com.u1fukui.bbs.model.BbsThread
 import com.u1fukui.bbs.model.ThreadListResponse
 import com.u1fukui.bbs.model.User
-
-import java.util.ArrayList
-import java.util.Date
-
 import io.reactivex.Single
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.schedulers.Schedulers
+import java.util.*
 
-class FavoriteThreadListRepository : ThreadListRepository {
+class FavoriteThreadListRepository constructor(
+        private val threadListApi: ThreadListApi
+) : ThreadListRepository {
 
-    override fun fetchThreadList(lastId: Long): Single<ThreadListResponse> {
-        //TODO: APIを使う
-        return Single.create { e ->
-            SystemClock.sleep(1000)
+    override fun fetchThreadList(lastId: Long): Single<ThreadListResponse> =
+            threadListApi.search("android")
+                    .subscribeOn(Schedulers.io())
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .map {
+                        ThreadListResponse(200,
+                                createDebugDataList(lastId),
+                                lastId >= 100)
+                    }
 
-            val list = ArrayList<BbsThread>()
-            for (i in lastId + 1..lastId + 20) {
-                val author = User(i, "作者" + i)
-                list.add(BbsThread(i, "お気に入りスレッド" + i, author, 0, Date(), Date()))
+    private fun createDebugDataList(lastId: Long): List<BbsThread> =
+            ((lastId + 1)..(lastId + 20)).map {
+                BbsThread(
+                        it,
+                        "お気に入りスレッド$it",
+                        User(it, "作者$it"),
+                        0,
+                        Date(),
+                        Date()
+                )
             }
-
-            e.onSuccess(ThreadListResponse(200, list, lastId >= 100))
-        }
-    }
 }

--- a/app/src/main/java/com/u1fukui/bbs/repository/HistoryThreadListRepository.kt
+++ b/app/src/main/java/com/u1fukui/bbs/repository/HistoryThreadListRepository.kt
@@ -1,31 +1,38 @@
 package com.u1fukui.bbs.repository
 
 
-import android.os.SystemClock
-
+import com.u1fukui.bbs.api.ThreadListApi
 import com.u1fukui.bbs.model.BbsThread
 import com.u1fukui.bbs.model.ThreadListResponse
 import com.u1fukui.bbs.model.User
-
-import java.util.ArrayList
-import java.util.Date
-
 import io.reactivex.Single
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.schedulers.Schedulers
+import java.util.*
 
-class HistoryThreadListRepository : ThreadListRepository {
+class HistoryThreadListRepository constructor(
+        private val threadListApi: ThreadListApi
+) : ThreadListRepository {
 
-    override fun fetchThreadList(lastId: Long): Single<ThreadListResponse> {
-        //TODO: APIを使う
-        return Single.create { e ->
-            SystemClock.sleep(1000)
+    override fun fetchThreadList(lastId: Long): Single<ThreadListResponse> =
+            threadListApi.search("android")
+                    .subscribeOn(Schedulers.io())
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .map {
+                        ThreadListResponse(200,
+                                createDebugDataList(lastId),
+                                lastId >= 100)
+                    }
 
-            val list = ArrayList<BbsThread>()
-            for (i in lastId + 1..lastId + 20) {
-                val author = User(i, "作者" + i)
-                list.add(BbsThread(i, "閲覧履歴スレッド" + i, author, 0, Date(), Date()))
+    private fun createDebugDataList(lastId: Long): List<BbsThread> =
+            ((lastId + 1)..(lastId + 20)).map {
+                BbsThread(
+                        it,
+                        "履歴スレッド$it",
+                        User(it, "作者$it"),
+                        0,
+                        Date(),
+                        Date()
+                )
             }
-
-            e.onSuccess(ThreadListResponse(200, list, lastId >= 100))
-        }
-    }
 }

--- a/app/src/main/java/com/u1fukui/bbs/repository/thread_list/CategoryListRepository.kt
+++ b/app/src/main/java/com/u1fukui/bbs/repository/thread_list/CategoryListRepository.kt
@@ -1,10 +1,10 @@
-package com.u1fukui.bbs.repository
+package com.u1fukui.bbs.repository.thread_list
 
 
 import android.os.SystemClock
 import com.u1fukui.bbs.model.Category
 import io.reactivex.Single
-import java.util.ArrayList;
+import java.util.*
 import javax.inject.Inject
 
 class CategoryListRepository @Inject constructor(

--- a/app/src/main/java/com/u1fukui/bbs/repository/thread_list/CategoryThreadListRepository.kt
+++ b/app/src/main/java/com/u1fukui/bbs/repository/thread_list/CategoryThreadListRepository.kt
@@ -1,4 +1,4 @@
-package com.u1fukui.bbs.repository
+package com.u1fukui.bbs.repository.thread_list
 
 
 import com.u1fukui.bbs.api.ThreadListApi
@@ -9,9 +9,11 @@ import io.reactivex.Single
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
 import java.util.*
+import javax.inject.Inject
 
-class HistoryThreadListRepository constructor(
-        private val threadListApi: ThreadListApi
+class CategoryThreadListRepository @Inject constructor(
+        private val threadListApi: ThreadListApi,
+        private val categoryId: Int
 ) : ThreadListRepository {
 
     override fun fetchThreadList(lastId: Long): Single<ThreadListResponse> =
@@ -19,7 +21,7 @@ class HistoryThreadListRepository constructor(
                     .subscribeOn(Schedulers.io())
                     .observeOn(AndroidSchedulers.mainThread())
                     .map {
-                        ThreadListResponse(200,
+                        ThreadListResponse(0,
                                 createDebugDataList(lastId),
                                 lastId >= 100)
                     }
@@ -27,9 +29,9 @@ class HistoryThreadListRepository constructor(
     private fun createDebugDataList(lastId: Long): List<BbsThread> =
             ((lastId + 1)..(lastId + 20)).map {
                 BbsThread(
-                        it,
-                        "履歴スレッド$it",
-                        User(it, "作者$it"),
+                        it.toLong(),
+                        "カテゴリスレッド$it",
+                        User(it.toLong(), "作者$it"),
                         0,
                         Date(),
                         Date()

--- a/app/src/main/java/com/u1fukui/bbs/repository/thread_list/FavoriteThreadListRepository.kt
+++ b/app/src/main/java/com/u1fukui/bbs/repository/thread_list/FavoriteThreadListRepository.kt
@@ -1,4 +1,4 @@
-package com.u1fukui.bbs.repository
+package com.u1fukui.bbs.repository.thread_list
 
 
 import com.u1fukui.bbs.api.ThreadListApi

--- a/app/src/main/java/com/u1fukui/bbs/repository/thread_list/HistoryThreadListRepository.kt
+++ b/app/src/main/java/com/u1fukui/bbs/repository/thread_list/HistoryThreadListRepository.kt
@@ -1,4 +1,4 @@
-package com.u1fukui.bbs.repository
+package com.u1fukui.bbs.repository.thread_list
 
 
 import com.u1fukui.bbs.api.ThreadListApi
@@ -9,11 +9,9 @@ import io.reactivex.Single
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
 import java.util.*
-import javax.inject.Inject
 
-class CategoryThreadListRepository @Inject constructor(
-        private val threadListApi: ThreadListApi,
-        private val categoryId: Int
+class HistoryThreadListRepository constructor(
+        private val threadListApi: ThreadListApi
 ) : ThreadListRepository {
 
     override fun fetchThreadList(lastId: Long): Single<ThreadListResponse> =
@@ -21,7 +19,7 @@ class CategoryThreadListRepository @Inject constructor(
                     .subscribeOn(Schedulers.io())
                     .observeOn(AndroidSchedulers.mainThread())
                     .map {
-                        ThreadListResponse(0,
+                        ThreadListResponse(200,
                                 createDebugDataList(lastId),
                                 lastId >= 100)
                     }
@@ -29,9 +27,9 @@ class CategoryThreadListRepository @Inject constructor(
     private fun createDebugDataList(lastId: Long): List<BbsThread> =
             ((lastId + 1)..(lastId + 20)).map {
                 BbsThread(
-                        it.toLong(),
-                        "カテゴリスレッド$it",
-                        User(it.toLong(), "作者$it"),
+                        it,
+                        "履歴スレッド$it",
+                        User(it, "作者$it"),
                         0,
                         Date(),
                         Date()

--- a/app/src/main/java/com/u1fukui/bbs/repository/thread_list/ThreadListRepository.kt
+++ b/app/src/main/java/com/u1fukui/bbs/repository/thread_list/ThreadListRepository.kt
@@ -1,4 +1,4 @@
-package com.u1fukui.bbs.repository
+package com.u1fukui.bbs.repository.thread_list
 
 
 import com.u1fukui.bbs.model.ThreadListResponse

--- a/app/src/main/java/com/u1fukui/bbs/ui/creation/thread/SelectCategoryViewModel.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/creation/thread/SelectCategoryViewModel.kt
@@ -6,7 +6,7 @@ import android.databinding.ObservableList
 import com.u1fukui.bbs.customview.ErrorView
 import com.u1fukui.bbs.helper.LoadingManager
 import com.u1fukui.bbs.model.Category
-import com.u1fukui.bbs.repository.CategoryListRepository
+import com.u1fukui.bbs.repository.thread_list.CategoryListRepository
 import com.u1fukui.bbs.ui.ViewModel
 import io.reactivex.SingleObserver
 import io.reactivex.android.schedulers.AndroidSchedulers

--- a/app/src/main/java/com/u1fukui/bbs/ui/main/BaseThreadListFragment.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/main/BaseThreadListFragment.kt
@@ -13,7 +13,7 @@ import com.u1fukui.bbs.customview.ObservableListRecyclerAdapter
 import com.u1fukui.bbs.customview.RecyclerViewScrolledEndSubject
 import com.u1fukui.bbs.databinding.FragmentThreadListBinding
 import com.u1fukui.bbs.databinding.ViewThreadCellBinding
-import com.u1fukui.bbs.repository.ThreadListRepository
+import com.u1fukui.bbs.repository.thread_list.ThreadListRepository
 import dagger.android.support.DaggerFragment
 import io.reactivex.disposables.Disposables
 

--- a/app/src/main/java/com/u1fukui/bbs/ui/main/ThreadListViewModel.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/main/ThreadListViewModel.kt
@@ -7,7 +7,7 @@ import com.u1fukui.bbs.App
 import com.u1fukui.bbs.customview.ErrorView
 import com.u1fukui.bbs.helper.LoadingManager
 import com.u1fukui.bbs.model.ThreadListResponse
-import com.u1fukui.bbs.repository.ThreadListRepository
+import com.u1fukui.bbs.repository.thread_list.ThreadListRepository
 import com.u1fukui.bbs.ui.ViewModel
 import io.reactivex.SingleObserver
 import io.reactivex.android.schedulers.AndroidSchedulers

--- a/app/src/main/java/com/u1fukui/bbs/ui/main/home/CategoryThreadListFragment.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/main/home/CategoryThreadListFragment.kt
@@ -3,7 +3,7 @@ package com.u1fukui.bbs.ui.main.home
 import android.os.Bundle
 import com.u1fukui.bbs.api.ThreadListApi
 import com.u1fukui.bbs.model.Category
-import com.u1fukui.bbs.repository.CategoryThreadListRepository
+import com.u1fukui.bbs.repository.thread_list.CategoryThreadListRepository
 import com.u1fukui.bbs.ui.main.BaseThreadListFragment
 import javax.inject.Inject
 

--- a/app/src/main/java/com/u1fukui/bbs/ui/main/home/HomeViewModel.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/main/home/HomeViewModel.kt
@@ -6,7 +6,7 @@ import android.view.View
 import com.u1fukui.bbs.customview.ErrorView
 import com.u1fukui.bbs.helper.LoadingManager
 import com.u1fukui.bbs.model.Category
-import com.u1fukui.bbs.repository.CategoryListRepository
+import com.u1fukui.bbs.repository.thread_list.CategoryListRepository
 import com.u1fukui.bbs.ui.ViewModel
 import com.u1fukui.bbs.ui.main.MainNavigator
 import io.reactivex.SingleObserver

--- a/app/src/main/java/com/u1fukui/bbs/ui/main/mypage/FavoriteThreadListFragment.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/main/mypage/FavoriteThreadListFragment.kt
@@ -1,7 +1,7 @@
 package com.u1fukui.bbs.ui.main.mypage
 
 import com.u1fukui.bbs.api.ThreadListApi
-import com.u1fukui.bbs.repository.FavoriteThreadListRepository
+import com.u1fukui.bbs.repository.thread_list.FavoriteThreadListRepository
 import com.u1fukui.bbs.ui.main.BaseThreadListFragment
 import javax.inject.Inject
 

--- a/app/src/main/java/com/u1fukui/bbs/ui/main/mypage/FavoriteThreadListFragment.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/main/mypage/FavoriteThreadListFragment.kt
@@ -1,15 +1,19 @@
 package com.u1fukui.bbs.ui.main.mypage
 
+import com.u1fukui.bbs.api.ThreadListApi
 import com.u1fukui.bbs.repository.FavoriteThreadListRepository
 import com.u1fukui.bbs.ui.main.BaseThreadListFragment
+import javax.inject.Inject
 
 class FavoriteThreadListFragment : BaseThreadListFragment() {
 
-    override fun getRepository() = FavoriteThreadListRepository()
+    @Inject
+    lateinit var threadListApi: ThreadListApi
+
+    override fun getRepository() = FavoriteThreadListRepository(threadListApi)
 
     companion object {
 
-        @JvmStatic
         fun newInstance() = FavoriteThreadListFragment()
     }
 

--- a/app/src/main/java/com/u1fukui/bbs/ui/main/mypage/HistoryThreadListFragment.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/main/mypage/HistoryThreadListFragment.kt
@@ -1,15 +1,19 @@
 package com.u1fukui.bbs.ui.main.mypage
 
+import com.u1fukui.bbs.api.ThreadListApi
 import com.u1fukui.bbs.repository.HistoryThreadListRepository
 import com.u1fukui.bbs.ui.main.BaseThreadListFragment
+import javax.inject.Inject
 
 class HistoryThreadListFragment : BaseThreadListFragment() {
 
-    override fun getRepository() = HistoryThreadListRepository()
+    @Inject
+    lateinit var threadListApi: ThreadListApi
+
+    override fun getRepository() = HistoryThreadListRepository(threadListApi)
 
     companion object {
 
-        @JvmStatic
         fun newInstance() = HistoryThreadListFragment()
     }
 }

--- a/app/src/main/java/com/u1fukui/bbs/ui/main/mypage/HistoryThreadListFragment.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/main/mypage/HistoryThreadListFragment.kt
@@ -1,7 +1,7 @@
 package com.u1fukui.bbs.ui.main.mypage
 
 import com.u1fukui.bbs.api.ThreadListApi
-import com.u1fukui.bbs.repository.HistoryThreadListRepository
+import com.u1fukui.bbs.repository.thread_list.HistoryThreadListRepository
 import com.u1fukui.bbs.ui.main.BaseThreadListFragment
 import javax.inject.Inject
 


### PR DESCRIPTION
FavoriteThreadListFragment と HistoryThreadListFragment が、@inject してないのに DaggerFragment を継承していたので、表示するとクラッシュしてしまっていた。

## やったこと
- 他の ThreadListFragment 同様に、repository クラスを作成して inject する
- それらの fragment が inject 対象になっていなかったので、module の記述を追加
- fragment 毎に module を作っていたが、それほど固有の fragment 用の処理は増えそうにないと思われるので、一般的な Activity や Fragment で使われる module を ActivityModule / FragmentModule として、それ以外に必要になったらそれぞれの Activity/Fragment に必要な module を作成するような設計にした
  - Activity は各 Actiivty 毎の固有の処理が今後出てきそうな気がしたので、消さずに残しておいた
- thread list 系の repository が増えてきたのでパッケージを作成して分離した