### PR TITLE
Update gradle plugin version for Android Studio 3.1 RC3.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -73,7 +73,7 @@ dependencies {
 
     // Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
-    kapt 'com.android.databinding:compiler:3.0.0'
+    kapt 'com.android.databinding:compiler:3.1.0-rc03'
 }
 repositories {
     mavenCentral()

--- a/app/src/main/java/com/u1fukui/bbs/customview/BindingHolder.kt
+++ b/app/src/main/java/com/u1fukui/bbs/customview/BindingHolder.kt
@@ -16,5 +16,5 @@ class BindingHolder<out T : ViewDataBinding>(
         LayoutInflater.from(context).inflate(layoutResId, parent, false)
 ) {
 
-    val binding: T = DataBindingUtil.bind(itemView)
+    val binding: T? = DataBindingUtil.bind(itemView)
 }

--- a/app/src/main/java/com/u1fukui/bbs/ui/creation/thread/SelectCategoryFragment.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/creation/thread/SelectCategoryFragment.kt
@@ -46,7 +46,7 @@ class SelectCategoryFragment : DaggerFragment() {
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = BindingHolder<ViewCategoryCellBinding>(parent.context, parent, R.layout.view_category_cell)
 
         override fun onBindViewHolder(holder: BindingHolder<ViewCategoryCellBinding>, position: Int) {
-            holder.binding.apply {
+            holder.binding?.apply {
                 bindingModel = getItem(position)
                 executePendingBindings()
             }

--- a/app/src/main/java/com/u1fukui/bbs/ui/detail/ThreadDetailActivity.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/detail/ThreadDetailActivity.kt
@@ -65,7 +65,7 @@ class ThreadDetailActivity : BaseActivity() {
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = BindingHolder<ViewCommentCellBinding>(parent.context, parent, R.layout.view_comment_cell)
 
         override fun onBindViewHolder(holder: BindingHolder<ViewCommentCellBinding>, position: Int) {
-            holder.binding.apply {
+            holder.binding?.apply {
                 bindingModel = getItem(position)
                 executePendingBindings()
             }

--- a/app/src/main/java/com/u1fukui/bbs/ui/main/BaseThreadListFragment.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/main/BaseThreadListFragment.kt
@@ -90,7 +90,7 @@ abstract class BaseThreadListFragment : DaggerFragment() {
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = BindingHolder<ViewThreadCellBinding>(parent.context, parent, R.layout.view_thread_cell)
 
         override fun onBindViewHolder(holder: BindingHolder<ViewThreadCellBinding>, position: Int) {
-            holder.binding.apply {
+            holder.binding?.apply {
                 bindingModel = getItem(position)
                 executePendingBindings()
             }

--- a/app/src/main/java/com/u1fukui/bbs/ui/notification/NotificationListActivity.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/notification/NotificationListActivity.kt
@@ -53,7 +53,7 @@ class NotificationListActivity : BaseActivity() {
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = BindingHolder<ViewNotificationCellBinding>(parent.context, parent, R.layout.view_notification_cell)
 
         override fun onBindViewHolder(holder: BindingHolder<ViewNotificationCellBinding>, position: Int) {
-            holder.binding.apply {
+            holder.binding?.apply {
                 bindingModel = getItem(position)
                 executePendingBindings()
             }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.0-rc03'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Oct 06 14:09:31 JST 2017
+#Wed Mar 21 18:01:32 JST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
Android Studio RC3 への更新に伴う対応作業。

## やったこと
- android gradle plugin を 3.1.0-rc3 に更新
- databinding compiler もそれに合わせろとエラーが出たので更新
- `DataBindingUtil.bind(View)` の返り値が Nullable になっていたので対応