### PR TITLE
Update gradle plugin and kotlin version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ ext {
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+    buildToolsVersion '28.0.3'
     defaultConfig {
         applicationId "com.u1fukui.bbs"
         minSdkVersion 21
@@ -84,7 +84,7 @@ dependencies {
     implementation "com.squareup.okhttp3:logging-interceptor:$okhttp_version"
     implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
     implementation "com.squareup.retrofit2:converter-moshi:$retrofit_version"
-    implementation 'com.jakewharton.retrofit:retrofit2-kotlin-coroutines-experimental-adapter:1.0.0'
+    implementation 'com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter:0.9.2'
     implementation "com.squareup.moshi:moshi:$moshi_version"
     implementation "com.squareup.moshi:moshi-kotlin:$moshi_version"
     implementation "se.ansman.kotshi:api:$koshi_version"
@@ -94,7 +94,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Kotlin
-    def coroutines_version = "0.23.0"
+    def coroutines_version = "1.1.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"

--- a/app/src/main/java/com/u1fukui/bbs/api/ThreadApi.kt
+++ b/app/src/main/java/com/u1fukui/bbs/api/ThreadApi.kt
@@ -1,7 +1,7 @@
 package com.u1fukui.bbs.api
 
 import com.u1fukui.bbs.model.Comment
-import kotlinx.coroutines.experimental.Deferred
+import kotlinx.coroutines.Deferred
 import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.Query

--- a/app/src/main/java/com/u1fukui/bbs/api/ThreadListApi.kt
+++ b/app/src/main/java/com/u1fukui/bbs/api/ThreadListApi.kt
@@ -1,7 +1,7 @@
 package com.u1fukui.bbs.api
 
 import com.u1fukui.bbs.model.BbsThread
-import kotlinx.coroutines.experimental.Deferred
+import kotlinx.coroutines.Deferred
 import retrofit2.http.GET
 import retrofit2.http.Query
 

--- a/app/src/main/java/com/u1fukui/bbs/di/AppModule.kt
+++ b/app/src/main/java/com/u1fukui/bbs/di/AppModule.kt
@@ -1,7 +1,7 @@
 package com.u1fukui.bbs.di
 
 import android.content.Context
-import com.jakewharton.retrofit2.adapter.kotlin.coroutines.experimental.CoroutineCallAdapterFactory
+import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import com.squareup.moshi.Moshi
 import com.u1fukui.bbs.App
 import com.u1fukui.bbs.BuildConfig
@@ -14,9 +14,10 @@ import com.u1fukui.bbs.model.User
 import com.u1fukui.bbs.network.ApplicationJsonAdapterFactory
 import dagger.Module
 import dagger.Provides
-import kotlinx.coroutines.experimental.CommonPool
-import kotlinx.coroutines.experimental.Deferred
-import kotlinx.coroutines.experimental.async
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.async
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
@@ -70,7 +71,7 @@ class AppModule(private val app: App) {
                 lastId: Long?,
                 pageSize: Int
             ): Deferred<List<BbsThread>> =
-                async(CommonPool) {
+                GlobalScope.async {
                     val key = lastId ?: 0
                     createThreadDebugList(key, pageSize)
                 }
@@ -101,7 +102,7 @@ class AppModule(private val app: App) {
                 lastId: Long?,
                 pageSize: Int
             ): Deferred<List<Comment>> =
-                async(CommonPool) {
+                GlobalScope.async(Dispatchers.Default) {
                     val key = lastId ?: 0
                     createCommentDebugList(threadId, key, pageSize)
                 }

--- a/app/src/main/java/com/u1fukui/bbs/paging/comment/CommentDataSourceFactory.kt
+++ b/app/src/main/java/com/u1fukui/bbs/paging/comment/CommentDataSourceFactory.kt
@@ -3,15 +3,16 @@ package com.u1fukui.bbs.paging.comment
 import android.arch.paging.DataSource
 import com.u1fukui.bbs.model.Comment
 import com.u1fukui.bbs.repository.ThreadRepository
-import kotlinx.coroutines.experimental.Job
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 
 class CommentDataSourceFactory(
     repository: ThreadRepository,
     threadId: Long,
-    job: Job
+    coroutineScope: CoroutineScope
 ) : DataSource.Factory<Long, Comment>() {
 
-    val source = PageKeyedCommentDataSource(repository, threadId, job)
+    val source = PageKeyedCommentDataSource(repository, threadId, coroutineScope)
 
     override fun create(): DataSource<Long, Comment> = source
 }

--- a/app/src/main/java/com/u1fukui/bbs/paging/comment/PageKeyedCommentDataSource.kt
+++ b/app/src/main/java/com/u1fukui/bbs/paging/comment/PageKeyedCommentDataSource.kt
@@ -5,14 +5,13 @@ import android.arch.paging.PageKeyedDataSource
 import com.u1fukui.bbs.model.Comment
 import com.u1fukui.bbs.paging.NetworkState
 import com.u1fukui.bbs.repository.ThreadRepository
-import kotlinx.coroutines.experimental.Job
-import kotlinx.coroutines.experimental.android.UI
-import kotlinx.coroutines.experimental.launch
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 class PageKeyedCommentDataSource(
     private val repository: ThreadRepository,
     private val threadId: Long,
-    private val job: Job
+    private val coroutineScope: CoroutineScope
 ) : PageKeyedDataSource<Long, Comment>() {
 
     val networkState = MutableLiveData<NetworkState>()
@@ -51,7 +50,7 @@ class PageKeyedCommentDataSource(
     ) {
         val isInitial = lastId == null
         updateNetworkState(NetworkState.LOADING, isInitial)
-        launch(job + UI) {
+        coroutineScope.launch {
             try {
                 repository.fetchCommentList(threadId, lastId, size).await()
                     .let {

--- a/app/src/main/java/com/u1fukui/bbs/paging/thread/PageKeyedThreadDataSource.kt
+++ b/app/src/main/java/com/u1fukui/bbs/paging/thread/PageKeyedThreadDataSource.kt
@@ -5,13 +5,12 @@ import android.arch.paging.PageKeyedDataSource
 import com.u1fukui.bbs.model.BbsThread
 import com.u1fukui.bbs.paging.NetworkState
 import com.u1fukui.bbs.repository.thread_list.ThreadListRepository
-import kotlinx.coroutines.experimental.Job
-import kotlinx.coroutines.experimental.android.UI
-import kotlinx.coroutines.experimental.launch
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 class PageKeyedThreadDataSource(
     private val repository: ThreadListRepository,
-    private val job: Job
+    private val coroutineScope: CoroutineScope
 ) : PageKeyedDataSource<Long, BbsThread>() {
 
     val networkState = MutableLiveData<NetworkState>()
@@ -50,7 +49,7 @@ class PageKeyedThreadDataSource(
     ) {
         val isInitial = lastId == null
         updateNetworkState(NetworkState.LOADING, isInitial)
-        launch(job + UI) {
+        coroutineScope.launch {
             try {
                 repository.fetchThreadList(lastId, size).await()
                     .let {

--- a/app/src/main/java/com/u1fukui/bbs/paging/thread/ThreadDataSourceFactory.kt
+++ b/app/src/main/java/com/u1fukui/bbs/paging/thread/ThreadDataSourceFactory.kt
@@ -3,14 +3,14 @@ package com.u1fukui.bbs.paging.thread
 import android.arch.paging.DataSource
 import com.u1fukui.bbs.model.BbsThread
 import com.u1fukui.bbs.repository.thread_list.ThreadListRepository
-import kotlinx.coroutines.experimental.Job
+import kotlinx.coroutines.CoroutineScope
 
 class ThreadDataSourceFactory(
     repository: ThreadListRepository,
-    job: Job
+    coroutineScope: CoroutineScope
 ) : DataSource.Factory<Long, BbsThread>() {
 
-    val source = PageKeyedThreadDataSource(repository, job)
+    val source = PageKeyedThreadDataSource(repository, coroutineScope)
 
     override fun create(): DataSource<Long, BbsThread> = source
 }

--- a/app/src/main/java/com/u1fukui/bbs/repository/ThreadRepository.kt
+++ b/app/src/main/java/com/u1fukui/bbs/repository/ThreadRepository.kt
@@ -7,7 +7,7 @@ import com.u1fukui.bbs.model.ApiResponse
 import com.u1fukui.bbs.model.Comment
 import com.u1fukui.bbs.model.EmptyResponse
 import io.reactivex.Single
-import kotlinx.coroutines.experimental.Deferred
+import kotlinx.coroutines.Deferred
 
 class ThreadRepository(private val threadApi: ThreadApi) {
 

--- a/app/src/main/java/com/u1fukui/bbs/repository/thread_list/CategoryThreadListRepository.kt
+++ b/app/src/main/java/com/u1fukui/bbs/repository/thread_list/CategoryThreadListRepository.kt
@@ -2,7 +2,7 @@ package com.u1fukui.bbs.repository.thread_list
 
 import com.u1fukui.bbs.api.ThreadListApi
 import com.u1fukui.bbs.model.BbsThread
-import kotlinx.coroutines.experimental.Deferred
+import kotlinx.coroutines.Deferred
 import javax.inject.Inject
 
 class CategoryThreadListRepository @Inject constructor(

--- a/app/src/main/java/com/u1fukui/bbs/repository/thread_list/FavoriteThreadListRepository.kt
+++ b/app/src/main/java/com/u1fukui/bbs/repository/thread_list/FavoriteThreadListRepository.kt
@@ -2,7 +2,7 @@ package com.u1fukui.bbs.repository.thread_list
 
 import com.u1fukui.bbs.api.ThreadListApi
 import com.u1fukui.bbs.model.BbsThread
-import kotlinx.coroutines.experimental.Deferred
+import kotlinx.coroutines.Deferred
 
 class FavoriteThreadListRepository constructor(
     private val threadListApi: ThreadListApi

--- a/app/src/main/java/com/u1fukui/bbs/repository/thread_list/HistoryThreadListRepository.kt
+++ b/app/src/main/java/com/u1fukui/bbs/repository/thread_list/HistoryThreadListRepository.kt
@@ -2,7 +2,7 @@ package com.u1fukui.bbs.repository.thread_list
 
 import com.u1fukui.bbs.api.ThreadListApi
 import com.u1fukui.bbs.model.BbsThread
-import kotlinx.coroutines.experimental.Deferred
+import kotlinx.coroutines.Deferred
 
 class HistoryThreadListRepository constructor(
     private val threadListApi: ThreadListApi

--- a/app/src/main/java/com/u1fukui/bbs/repository/thread_list/ThreadListRepository.kt
+++ b/app/src/main/java/com/u1fukui/bbs/repository/thread_list/ThreadListRepository.kt
@@ -1,7 +1,7 @@
 package com.u1fukui.bbs.repository.thread_list
 
 import com.u1fukui.bbs.model.BbsThread
-import kotlinx.coroutines.experimental.Deferred
+import kotlinx.coroutines.Deferred
 
 interface ThreadListRepository {
 

--- a/app/src/main/java/com/u1fukui/bbs/ui/main/ThreadListViewModel.kt
+++ b/app/src/main/java/com/u1fukui/bbs/ui/main/ThreadListViewModel.kt
@@ -14,13 +14,21 @@ import com.u1fukui.bbs.helper.LoadingManager
 import com.u1fukui.bbs.paging.Status
 import com.u1fukui.bbs.paging.thread.ThreadDataSourceFactory
 import com.u1fukui.bbs.repository.thread_list.ThreadListRepository
-import kotlinx.coroutines.experimental.Job
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlin.coroutines.CoroutineContext
 
 class ThreadListViewModel(
     private val owner: LifecycleOwner,
     private val repository: ThreadListRepository,
     private val navigator: ThreadListNavigator
-) : ViewModel(), ErrorView.ErrorViewListener {
+) : ViewModel(), ErrorView.ErrorViewListener, CoroutineScope {
+
+    //region CoroutineScope
+    override val coroutineContext: CoroutineContext
+        get() = Dispatchers.Main + job
+    //endregion
 
     //region DataBinding
     val loadingManager = LoadingManager()
@@ -33,7 +41,7 @@ class ThreadListViewModel(
 
     private val job = Job()
 
-    private val factory = ThreadDataSourceFactory(repository, job)
+    private val factory = ThreadDataSourceFactory(repository, this)
 
     init {
         val config = PagedList.Config.Builder()

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.31'
+    ext.kotlin_version = '1.3.11'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
久々に開発しようとして、言われるがままに android gradle plugin version を上げたら、kotlin のバージョンアップも要求され、関連して coroutine 1.0 対応を行った。

## Kotlin 1.2 -> 1.3 系
- 概要はまだ調べてないが、coroutine が 1.0 になったのでその対応をする必要が出てきた

## Coroutine 1.0
- external が取れた
- `CommonPool` がなくなった
- `CoroutineScope` というものが出来ていた

とりあえずコンパイルエラーが消えて動作確認できる所まで対応した。
コルーチン周りは複雑そうなので詳細な調査は後日。